### PR TITLE
batch file that does the whole tmThemes dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .DS_Store
+colorSchemeTool.log

--- a/convert.sh
+++ b/convert.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+FILES=./tmThemes/*.tmTheme
+OUTDIR=./intellijThemes/
+
+shopt -s nullglob
+
+for FILE in $FILES
+do
+    FN="${FILE##*/}"
+    DIR="${FILE:0:${#FILE} - ${#FN}}"
+    BASE="${FN%.[^.]*}"
+    EXT="${FN:${#BASE} + 1}"
+    echo converting $DIR$FN$EXT to $OUTDIR$BASE.xml ...
+	python colorSchemeTool.py $FILE $OUTDIR$BASE.xml >> ./colorSchemeTool.log
+done


### PR DESCRIPTION
I had this file for an older version and I never sent it in, but I figured I should ;-)

It just runs the colorSchemeTool on the entire tmThemes dir, so you don't have to edit the run.sh file. 

It also redirects the colorSchemeTool output to a file (colorSchemeTool.log) instead of displaying in the terminal. 

Thanks for releasing the colorSchemeTool and everything else!
