### PR TITLE
Do not introduce bright diff colors for Darcula-based themes

### DIFF
--- a/colorSchemeTool.py
+++ b/colorSchemeTool.py
@@ -207,10 +207,6 @@ for id in [
            "CONSOLE_CYAN_OUTPUT",
            "CONSOLE_GRAY_OUTPUT",
            "CONSOLE_SYSTEM_OUTPUT",
-           "DIFF_MODIFIED",                           # DiffColors
-           "DIFF_DELETED",
-           "DIFF_INSERTED",
-           "DIFF_CONFLICT",
            "CUSTOM_KEYWORD1_ATTRIBUTES",              # CustomHighlighterColors
            "CUSTOM_KEYWORD2_ATTRIBUTES",
            "CUSTOM_KEYWORD3_ATTRIBUTES",

--- a/intellijThemes/Active4D.icls
+++ b/intellijThemes/Active4D.icls
@@ -503,30 +503,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="AF82D4" />

--- a/intellijThemes/All Hallow's Eve.icls
+++ b/intellijThemes/All Hallow's Eve.icls
@@ -485,30 +485,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="9933CC" />

--- a/intellijThemes/Amy.icls
+++ b/intellijThemes/Amy.icls
@@ -560,30 +560,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="404080" />

--- a/intellijThemes/Blackboard.icls
+++ b/intellijThemes/Blackboard.icls
@@ -519,30 +519,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="AEAEAE" />

--- a/intellijThemes/Cobalt.icls
+++ b/intellijThemes/Cobalt.icls
@@ -647,30 +647,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="0088FF" />

--- a/intellijThemes/Dawn.icls
+++ b/intellijThemes/Dawn.icls
@@ -553,30 +553,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="5A525F" />

--- a/intellijThemes/Eiffel.icls
+++ b/intellijThemes/Eiffel.icls
@@ -581,30 +581,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="00B418" />

--- a/intellijThemes/Espresso Libre.icls
+++ b/intellijThemes/Espresso Libre.icls
@@ -576,30 +576,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="0066FF" />

--- a/intellijThemes/Github.icls
+++ b/intellijThemes/Github.icls
@@ -570,30 +570,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="DD1144" />

--- a/intellijThemes/IDLE.icls
+++ b/intellijThemes/IDLE.icls
@@ -453,30 +453,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="919191" />

--- a/intellijThemes/LAZY.icls
+++ b/intellijThemes/LAZY.icls
@@ -519,30 +519,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="8C868F" />

--- a/intellijThemes/Mac Classic.icls
+++ b/intellijThemes/Mac Classic.icls
@@ -591,30 +591,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="0066FF" />

--- a/intellijThemes/MagicWB (Amiga).icls
+++ b/intellijThemes/MagicWB (Amiga).icls
@@ -584,30 +584,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="8D2E75" />

--- a/intellijThemes/Monokai Bright.icls
+++ b/intellijThemes/Monokai Bright.icls
@@ -518,30 +518,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="75715E" />

--- a/intellijThemes/Monokai.icls
+++ b/intellijThemes/Monokai.icls
@@ -518,30 +518,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="75715E" />

--- a/intellijThemes/Pastels on Dark.icls
+++ b/intellijThemes/Pastels on Dark.icls
@@ -516,30 +516,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="555555" />

--- a/intellijThemes/Railscasts.icls
+++ b/intellijThemes/Railscasts.icls
@@ -556,30 +556,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="BC9458" />

--- a/intellijThemes/Slush & Poppies.icls
+++ b/intellijThemes/Slush & Poppies.icls
@@ -458,30 +458,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="406040" />

--- a/intellijThemes/Solarized (Dark).icls
+++ b/intellijThemes/Solarized (Dark).icls
@@ -507,30 +507,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="839496" />

--- a/intellijThemes/Solarized (Light).icls
+++ b/intellijThemes/Solarized (Light).icls
@@ -509,30 +509,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="839496" />

--- a/intellijThemes/SpaceCadet.icls
+++ b/intellijThemes/SpaceCadet.icls
@@ -528,30 +528,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="473C45" />

--- a/intellijThemes/Sunburst.icls
+++ b/intellijThemes/Sunburst.icls
@@ -568,30 +568,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="AEAEAE" />

--- a/intellijThemes/Twilight.icls
+++ b/intellijThemes/Twilight.icls
@@ -568,30 +568,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="5F5A60" />

--- a/intellijThemes/Zenburnesque.icls
+++ b/intellijThemes/Zenburnesque.icls
@@ -476,30 +476,6 @@
         <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="709070" />

--- a/intellijThemes/iPlastic.icls
+++ b/intellijThemes/iPlastic.icls
@@ -550,30 +550,6 @@
         <option name="EFFECT_COLOR" value="404040" />
       </value>
     </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="ffc8bd" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="cbcbcb" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="baeeba" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="bccff9" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
     <option name="DJANGO_COMMENT">
       <value>
         <option name="FOREGROUND" value="0066FF" />


### PR DESCRIPTION
Do not introduce bright diff colors for Darcula-based themes - reuse Darcula ones + another scheme update. 