### PR TITLE
25 ignore missing color keys

### DIFF
--- a/colorSchemeTool.py
+++ b/colorSchemeTool.py
@@ -711,7 +711,11 @@ def find_by_scope(settings, scope):
         if scope_of_setting is None:
             if scope is None: return setting
         else:
-            scopes_of_setting = scope_of_setting.split(",")
+            if not isinstance(scope_of_setting, list):
+                scopes_of_setting = scope_of_setting.split(",")
+            else:
+                scopes_of_setting = scope_of_setting
+
             for aScope in scopes_of_setting:
                 aScope = aScope.strip()
 

--- a/vscToTm.js
+++ b/vscToTm.js
@@ -7,10 +7,23 @@ function convert(vscTheme) {
         name: vscTheme.name,
         settings: vscTheme.tokenColors
     }
-    tmTheme.settings[0].settings.caret = vscTheme.colors["editorCursor.foreground"]
-    tmTheme.settings[0].settings.invisibles = vscTheme.colors["editorWhitespace.foreground"]
-    tmTheme.settings[0].settings.selection = vscTheme.colors["editor.selectionBackground"]
-    tmTheme.settings[0].settings.lineHighlight = vscTheme.colors["editor.lineHighlightBackground"]
+
+    const defaultSettings = tmTheme.settings.find(setting => !setting.scope);
+
+    if (!defaultSettings) {
+        tmTheme.settings.unshift({ settings: {}});
+    }
+
+    const tmThemeDefaultSettings = tmTheme.settings[0].settings;
+    const vscThemeColors = vscTheme.colors;
+
+    const mapper = new SettingsMapper({tmThemeDefaultSettings, vscThemeColors});
+    mapper.addSetting("editorCursor.foreground", "caret");
+    mapper.addSetting("editor.selectionBackground", "selection");
+    mapper.addSetting("editor.lineHighlightBackground", "lineHighlight");
+    mapper.addSetting("editor.foreground", "foreground");
+    mapper.addSetting("editor.background", "background");
+    mapper.addSetting("editorWhitespace.foreground", "invisibles");
     for (i = 1; i < tmTheme.settings.length; i++) {
        const scope = tmTheme.settings[i].scope
        if (scope) {
@@ -18,6 +31,19 @@ function convert(vscTheme) {
        } 
     }
     return tmTheme
+}
+
+class SettingsMapper {
+    constructor({ tmThemeDefaultSettings, vscThemeColors }) {
+        this.tmThemeDefaultSettings = tmThemeDefaultSettings;
+        this.vscThemeColors = vscThemeColors;
+    }
+
+    addSetting(fromKey, toKey) {
+        if (fromKey in this.vscThemeColors) {
+            this.tmThemeDefaultSettings[toKey] = this.vscThemeColors[fromKey]
+        }
+    }
 }
 
 const vscTheme = json5.parse(fs.readFileSync(process.argv[2], "utf8"))


### PR DESCRIPTION
- Vscode can now have an array of scopes (line 714)
- Added if statements to make sure that colorSchemeTool.py tools ignore keys the tmTheme does not have
- Conditionally adds keys to the tmTheme if the .json file actually has them (vscToTm.js)