### PR TITLE
Fix theme generation compatibility for VSCode 1.105+

### DIFF
--- a/vscToTm.js
+++ b/vscToTm.js
@@ -1,11 +1,21 @@
 const json5 = require('json5')
 const plist = require('plist')
 const fs = require('fs')
+const path = require('path')
 
-function convert(vscTheme) {
+function convert(vscTheme, inputFilePath) {
+    // Extract theme name from vscTheme.name, or fall back to filename without extension
+    let themeName = vscTheme.name;
+    if (!themeName && inputFilePath) {
+        themeName = path.basename(inputFilePath, path.extname(inputFilePath));
+    }
+    if (!themeName) {
+        themeName = 'Untitled Theme';
+    }
+
     const tmTheme = {
-        name: vscTheme.name,
-        settings: vscTheme.tokenColors
+        name: themeName,
+        settings: vscTheme.tokenColors || []
     }
 
     const defaultSettings = tmTheme.settings.find(setting => !setting.scope);
@@ -28,7 +38,7 @@ function convert(vscTheme) {
        const scope = tmTheme.settings[i].scope
        if (scope) {
            tmTheme.settings[i].scope = scope.toString()
-       } 
+       }
     }
     return tmTheme
 }
@@ -46,5 +56,7 @@ class SettingsMapper {
     }
 }
 
-const vscTheme = json5.parse(fs.readFileSync(process.argv[2], "utf8"))
-fs.writeFileSync(process.argv[3], plist.build(convert(vscTheme)))
+const inputFile = process.argv[2]
+const outputFile = process.argv[3]
+const vscTheme = json5.parse(fs.readFileSync(inputFile, "utf8"))
+fs.writeFileSync(outputFile, plist.build(convert(vscTheme, inputFile)))


### PR DESCRIPTION
**Problem**
Themes exported from VSCode using "Developer: Generate Color Theme From Current Settings" command don't have a `name` field at the top level of the JSON. The original code passed `undefined` directly to the plist builder, which spit out malformed XML:

```
<key>name</key>
<key>settings</key>  <!-- missing value element -->
```

Python's plistlib rightfully chokes on this with `ValueError: unexpected key at line 6`.

**Solution**
If there's no `name` in the theme JSON, derive it from the input filename:

```
let themeName = vscTheme.name;
if (!themeName && inputFilePath) {
    themeName = path.basename(inputFilePath, path.extname(inputFilePath));
}
```

**Context**
This appears to be the default export format in recent VSCode versions (tested on 1.105). Users attempting to convert a theme generated from their current VSCode settings would encounter this error.

**Changes**
- `vscToTm.js` - derive theme name from filename when not present in JSON